### PR TITLE
Chore/update configs

### DIFF
--- a/src/api/docs/paths/pagamento.ts
+++ b/src/api/docs/paths/pagamento.ts
@@ -177,7 +177,7 @@ export const PagamentoPaths = {
             },
         },
     },
-    "/pedido/{id}/update-status": {
+    "/pagamento/{id}/update-status": {
         patch: {
             tags: ["pagamento"],
             summary: "Rota para atualizar o status de um pagamento",

--- a/src/api/routes/pagamentoRouter.ts
+++ b/src/api/routes/pagamentoRouter.ts
@@ -16,12 +16,12 @@ export function makePagamentoRouter(): Router {
         pagamentoController.getById(req, res, next),
     );
 
-    pagamentoRouter.get("/getByPedido/:pedidoId", async (req, res, next) =>
-        pagamentoController.getByPedidoId(req, res, next),
-    );
-
     pagamentoRouter.patch("/:id/update-status", async (req, res, next) =>
         pagamentoController.patchStatus(req, res, next),
+    );
+
+    pagamentoRouter.get("/getByPedido/:pedidoId", async (req, res, next) =>
+        pagamentoController.getByPedidoId(req, res, next),
     );
 
     return pagamentoRouter;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,7 +2,7 @@ import { parseEnvInt, parseEnvStr } from "./utils";
 
 export const serverConfig = {
     env: parseEnvStr("NODE_ENV", "development"),
-    port: parseEnvInt("PORT", 6001),
+    port: parseEnvInt("PORT", 6003),
     isProduction: process.env.NODE_ENV === "production",
     isDevelopment: process.env.NODE_ENV === "development",
     mongo: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -24,7 +24,7 @@ export const serverConfig = {
     pedidosMicroService: {
         apiUrl: parseEnvStr(
             "PEDIDO_SVC_URL",
-            "http://localhost:6001/api/pedido",
+            "http://localhost:6004/api/pedido",
         ),
     }
 } as const;

--- a/src/controllers/pagamento/factory.ts
+++ b/src/controllers/pagamento/factory.ts
@@ -2,12 +2,17 @@ import { PagamentoUseCase } from "useCases";
 import { PagamentoMongoGateway } from "gateways";
 import { PagamentoModel } from "external/mongo/models";
 import { PagamentoController } from "./controller";
+import { PedidoSvcGateway } from "gateways/pedidoSvcGateway";
+import { pedidoSvcAPi } from "external/pedidoSvc";
 
 export class PagamentoControllerFactory {
     public static create(): PagamentoController {
         const pagamentoGateway = new PagamentoMongoGateway(PagamentoModel);
-        const pagamentoUseCase = new PagamentoUseCase(pagamentoGateway);
+        const pedidoSvcGateway = new PedidoSvcGateway(pedidoSvcAPi);
+        const pagamentoUseCase = new PagamentoUseCase(
+            pagamentoGateway,
+            pedidoSvcGateway,
+        );
         return new PagamentoController(pagamentoUseCase);
     }
 }
-

--- a/src/gateways/pedidoSvcGateway.ts
+++ b/src/gateways/pedidoSvcGateway.ts
@@ -4,10 +4,13 @@ import { PedidoSvcApi, PedidoSvcStatus } from "external/pedidoSvc";
 export class PedidoSvcGateway {
     constructor(private readonly pedidoSvcApi: PedidoSvcApi) {}
 
-    async updateOrderPaymentStatus(pedidoId: string, tipo: PagamentoTipoEnum): Promise<string> {
-        const { data } = await this.pedidoSvcApi.patch<{ qr_data: string }>(
-            `/${pedidoId}/update-payment-status`, { statusPagamento: this.parseStatusPedidoSvc(tipo) });
-        return data.qr_data;
+    async updateOrderPaymentStatus(
+        pedidoId: string,
+        tipo: PagamentoTipoEnum,
+    ): Promise<void> {
+        await this.pedidoSvcApi.patch(`/${pedidoId}/update-payment-status`, {
+            statusPagamento: this.parseStatusPedidoSvc(tipo),
+        });
     }
 
     parseStatusPedidoSvc(tipo: PagamentoTipoEnum): PedidoSvcStatus {


### PR DESCRIPTION
### Changelog:
- Atualiza default port para `6003`
- Corrige `pagamentoUseCase.updateStatus`
  - Passa a utilizar o PedidoSvcGateway por injeção de dependência
  - Utiliza pedidoId ao invés de pagamento.id
- Corrige `pedidoSvcGateway.updateOrderPaymentStatus`
  - Remove return type incorreto
  - Utiliza parametro no body correto `statusPagamento` 
- Corrige rota `/pedido/{id}/update-status` para `/pagamento/{id}/update-status` na documentação 
- Corrige ordem das rotas em `pagamentoRouter`
- Atualiza uso do `PagamentoUseCase` com a nova dependência