### PR TITLE
Feature/add payment status update saga

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "aws-sdk": "^2.1565.0",
         "axios": "^1.5.0",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
@@ -2324,6 +2325,40 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.1569.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1569.0.tgz",
+      "integrity": "sha512-9puKjesHKOjAYPqFurW/9nv3qhQ+STu3bVa5PN158SCeZPE6NsxZIWnHLglJvKU7N8UXJo1aJHmKDUGrsS7rXw==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
+        "xml2js": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
@@ -2456,6 +2491,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2582,6 +2636,16 @@
       "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
       "engines": {
         "node": ">=14.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "node_modules/buffer-from": {
@@ -3405,6 +3469,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -3787,6 +3859,14 @@
         }
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -4041,6 +4121,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
@@ -4092,6 +4186,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "node_modules/ignore": {
       "version": "5.3.0",
@@ -4174,6 +4273,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4190,6 +4304,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -4229,6 +4354,20 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -4272,6 +4411,25 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
+      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "dependencies": {
+        "which-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4898,6 +5056,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/js-tokens": {
@@ -5703,6 +5869,14 @@
         "node": ">=12"
       }
     },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5804,6 +5978,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/queue-lit": {
@@ -6043,6 +6226,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA=="
     },
     "node_modules/semver": {
       "version": "7.5.4",
@@ -6891,6 +7079,32 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6903,6 +7117,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -6977,6 +7199,24 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.14.tgz",
+      "integrity": "sha512-VnXFiIW8yNn9kIHN88xvZ4yOWchftKDsRJ8fEPacX/wl1lOvBrhsJ/OeJCXq7B0AaijRuqgzSKalJoPk+D8MPg==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.6",
+        "call-bind": "^1.0.5",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/winston": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.11.0.tgz",
@@ -7047,6 +7287,26 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/karineriquena/fiap-soat1-tech-challenge#readme",
   "dependencies": {
+    "aws-sdk": "^2.1565.0",
     "axios": "^1.5.0",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -26,5 +26,19 @@ export const serverConfig = {
             "PEDIDO_SVC_URL",
             "http://localhost:6004/api/pedido",
         ),
-    }
+    },
+    sqs: {
+        region: parseEnvStr("SQS_REGION", "us-east-1"),
+        accessKeyId: parseEnvStr("SQS_ACCESS_KEY_ID", "AKIASEKWN5VMCC3LDZNW"),
+        secretAccessKey: parseEnvStr(
+            "SQS_SECRET_ACCESS_KEY",
+            "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",
+        ),
+    },
+    queues: {
+        confirmacaoPagemento: parseEnvStr(
+            "QUEUE_CONFIRMACAO_PAGAMENTO",
+            "https://sqs.us-east-1.amazonaws.com/146747026776/confirmacao-pagamento",
+        ),
+    },
 } as const;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -28,12 +28,9 @@ export const serverConfig = {
         ),
     },
     sqs: {
-        region: parseEnvStr("SQS_REGION", "us-east-1"),
-        accessKeyId: parseEnvStr("SQS_ACCESS_KEY_ID", "AKIASEKWN5VMCC3LDZNW"),
-        secretAccessKey: parseEnvStr(
-            "SQS_SECRET_ACCESS_KEY",
-            "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",
-        ),
+        region: parseEnvStr("SQS_REGION"),
+        accessKeyId: parseEnvStr("SQS_ACCESS_KEY_ID"),
+        secretAccessKey: parseEnvStr("SQS_SECRET_ACCESS_KEY"),
     },
     queues: {
         confirmacaoPagemento: parseEnvStr(

--- a/src/controllers/pagamento/factory.ts
+++ b/src/controllers/pagamento/factory.ts
@@ -2,16 +2,22 @@ import { PagamentoUseCase } from "useCases";
 import { PagamentoMongoGateway } from "gateways";
 import { PagamentoModel } from "external/mongo/models";
 import { PagamentoController } from "./controller";
-import { PedidoSvcGateway } from "gateways/pedidoSvcGateway";
-import { pedidoSvcAPi } from "external/pedidoSvc";
+import { QueueManager } from "external/queueService";
+import { serverConfig } from "config";
+import { SQSClient } from "external/queueService/client";
 
 export class PagamentoControllerFactory {
     public static create(): PagamentoController {
         const pagamentoGateway = new PagamentoMongoGateway(PagamentoModel);
-        const pedidoSvcGateway = new PedidoSvcGateway(pedidoSvcAPi);
+        const pedidoQueueManager = new QueueManager(
+            serverConfig.queues.confirmacaoPagemento,
+            SQSClient,
+        );
+
         const pagamentoUseCase = new PagamentoUseCase(
+            PagamentoModel,
             pagamentoGateway,
-            pedidoSvcGateway,
+            pedidoQueueManager,
         );
         return new PagamentoController(pagamentoUseCase);
     }

--- a/src/external/pedidoSvc/types/pedidoSvcEvent.ts
+++ b/src/external/pedidoSvc/types/pedidoSvcEvent.ts
@@ -1,5 +1,8 @@
-export type PedidoSvcStatus = "pagamento_pendente" | "pagamento_aprovado" | "pagamento_nao_autorizado";
+export type PedidoStatus =
+    | "pagamento_pendente"
+    | "pagamento_aprovado"
+    | "pagamento_nao_autorizado";
 
 export interface PedidoSvcEvent {
-  pagamento: PedidoSvcStatus;
+    pagamento: PedidoStatus;
 }

--- a/src/external/queueService/client/index.ts
+++ b/src/external/queueService/client/index.ts
@@ -1,0 +1,8 @@
+import { SQS } from "aws-sdk";
+import { serverConfig } from "config";
+
+export const SQSClient = new SQS({
+    region: serverConfig.sqs.region,
+    accessKeyId: serverConfig.sqs.accessKeyId,
+    secretAccessKey: serverConfig.sqs.secretAccessKey,
+});

--- a/src/external/queueService/helpers/queueManager.ts
+++ b/src/external/queueService/helpers/queueManager.ts
@@ -1,0 +1,17 @@
+import { SQSClient } from "../client";
+
+export class QueueManager {
+    constructor(
+        private readonly queueUrl: string,
+        private readonly queueClient: typeof SQSClient,
+    ) {}
+
+    async enqueueMessage(message: string): Promise<void> {
+        await this.queueClient
+            .sendMessage({
+                QueueUrl: this.queueUrl,
+                MessageBody: message,
+            })
+            .promise();
+    }
+}

--- a/src/external/queueService/index.ts
+++ b/src/external/queueService/index.ts
@@ -1,0 +1,1 @@
+export * from "./helpers/queueManager";

--- a/src/gateways/pagamentoGateway.ts
+++ b/src/gateways/pagamentoGateway.ts
@@ -3,6 +3,7 @@ import { PagamentoGateway } from "interfaces/gateways";
 import { Pagamento, PagamentoTipoEnum } from "entities/pagamento";
 import { PagamentoModel } from "external/mongo/models";
 import { PagamentoMapper } from "adapters/mappers";
+import { ClientSession } from "mongoose";
 
 export class PagamentoMongoGateway implements PagamentoGateway {
     constructor(private readonly pagamentoModel: typeof PagamentoModel) {}
@@ -18,7 +19,7 @@ export class PagamentoMongoGateway implements PagamentoGateway {
             id: result.id,
             pedidoId: result.pedidoId,
             tipo: result.tipo,
-            valorTotal: result.valorTotal
+            valorTotal: result.valorTotal,
         });
     }
 
@@ -34,14 +35,12 @@ export class PagamentoMongoGateway implements PagamentoGateway {
             .sort({ createdAt: 1 });
 
         return results.map((result) =>
-            PagamentoMapper.toDomain(
-                {
-                    id: result._id,
-                    tipo: result.tipo,
-                    pedidoId: result.pedidoId,
-                    valorTotal: result.valorTotal,
-                },
-            ),
+            PagamentoMapper.toDomain({
+                id: result._id,
+                tipo: result.tipo,
+                pedidoId: result.pedidoId,
+                valorTotal: result.valorTotal,
+            }),
         );
     }
 
@@ -52,35 +51,35 @@ export class PagamentoMongoGateway implements PagamentoGateway {
         });
 
         if (result) {
-            return PagamentoMapper.toDomain(
-                {
-                    id: result.id,
-                    tipo: result.tipo,
-                    pedidoId: result.pedidoId,
-                    valorTotal: result.valorTotal,
-                },
-            );
+            return PagamentoMapper.toDomain({
+                id: result.id,
+                tipo: result.tipo,
+                pedidoId: result.pedidoId,
+                valorTotal: result.valorTotal,
+            });
         }
-
     }
 
-    async updateStatus(id: string, status: PagamentoTipoEnum): Promise<Pagamento> {
+    async updateStatus(
+        id: string,
+        status: PagamentoTipoEnum,
+        session: ClientSession,
+    ): Promise<Pagamento> {
         const result = await this.pagamentoModel.findOneAndUpdate(
             { _id: id },
             { tipo: status },
             {
                 new: true,
+                session,
             },
         );
 
-        return PagamentoMapper.toDomain(
-            {
-                id: result.id,
-                tipo: result.tipo,
-                pedidoId: result.pedidoId,
-                valorTotal: result.valorTotal,
-            },
-        );
+        return PagamentoMapper.toDomain({
+            id: result.id,
+            tipo: result.tipo,
+            pedidoId: result.pedidoId,
+            valorTotal: result.valorTotal,
+        });
     }
 
     async getByPedidoId(pedidoId: string): Promise<Pagamento> {
@@ -90,18 +89,16 @@ export class PagamentoMongoGateway implements PagamentoGateway {
         });
 
         if (result) {
-            return PagamentoMapper.toDomain(
-                {
-                    id: result.id,
-                    tipo: result.tipo,
-                    pedidoId: result.pedidoId,
-                    valorTotal: result.valorTotal,
-                },
-            );
+            return PagamentoMapper.toDomain({
+                id: result.id,
+                tipo: result.tipo,
+                pedidoId: result.pedidoId,
+                valorTotal: result.valorTotal,
+            });
         }
     }
 
-    async checkDuplicate(args: { pedidoId: string; }): Promise<boolean> {
+    async checkDuplicate(args: { pedidoId: string }): Promise<boolean> {
         const result = await this.pagamentoModel.count({
             pedidoId: args.pedidoId,
             deleted: { $ne: true },

--- a/src/gateways/pedidoSvcGateway.ts
+++ b/src/gateways/pedidoSvcGateway.ts
@@ -1,5 +1,5 @@
 import { PagamentoTipoEnum } from "entities/pagamento";
-import { PedidoSvcApi, PedidoSvcStatus } from "external/pedidoSvc";
+import { PedidoSvcApi, PedidoStatus } from "external/pedidoSvc";
 
 export class PedidoSvcGateway {
     constructor(private readonly pedidoSvcApi: PedidoSvcApi) {}
@@ -13,7 +13,7 @@ export class PedidoSvcGateway {
         });
     }
 
-    parseStatusPedidoSvc(tipo: PagamentoTipoEnum): PedidoSvcStatus {
+    parseStatusPedidoSvc(tipo: PagamentoTipoEnum): PedidoStatus {
         const statusMap = {
             [PagamentoTipoEnum.Aprovado]: "pagamento_aprovado",
             [PagamentoTipoEnum.Recusado]: "pagamento_nao_autorizado",
@@ -21,6 +21,6 @@ export class PedidoSvcGateway {
 
         const status = statusMap[tipo] || "pagamento_pendente";
 
-        return status as PedidoSvcStatus;
+        return status as PedidoStatus;
     }
 }

--- a/src/interfaces/gateways/pagamentoGateway.interface.ts
+++ b/src/interfaces/gateways/pagamentoGateway.interface.ts
@@ -1,11 +1,16 @@
 import { Pagamento, PagamentoTipoEnum } from "entities/pagamento";
+import { ClientSession } from "mongoose";
 import { PagamentoDTO } from "useCases";
 
 export interface PagamentoGateway {
-  create(pagamento: PagamentoDTO): Promise<Pagamento>;
-  getAll(filters?: Partial<Pagamento>): Promise<Pagamento[]>;
-  getById(id: string): Promise<Pagamento>;
-  updateStatus (id: string, status: PagamentoTipoEnum): Promise<Pagamento>;
-  getByPedidoId(pedidoId: string): Promise<Pagamento>;
-  checkDuplicate(args: { pedidoId: string }): Promise<boolean>;
+    create(pagamento: PagamentoDTO): Promise<Pagamento>;
+    getAll(filters?: Partial<Pagamento>): Promise<Pagamento[]>;
+    getById(id: string): Promise<Pagamento>;
+    updateStatus(
+        id: string,
+        status: PagamentoTipoEnum,
+        session: ClientSession,
+    ): Promise<Pagamento>;
+    getByPedidoId(pedidoId: string): Promise<Pagamento>;
+    checkDuplicate(args: { pedidoId: string }): Promise<boolean>;
 }

--- a/src/useCases/pagamentoEventMock/pagamentoEventMockUseCase.ts
+++ b/src/useCases/pagamentoEventMock/pagamentoEventMockUseCase.ts
@@ -28,6 +28,7 @@ export class PagamentoEventMockUseCase implements IPagamentoEventMockUseCase {
         await this.pagamentoGateway.updateStatus(
             pagamento.id,
             tipo as PagamentoTipoEnum,
+            null,
         );
     }
 }


### PR DESCRIPTION
### Changelog:
- Adiciona package `aws-sdk`
- Adiciona config para:
  - Client SQS
  - E filas utilizadas
- Adiciona novo serviço externo `QueueManager`
  - Helper simplificado só com função para enfileirar mensagem
- Refatora `PagamentoUseCase.updateStatus`
  - Atualiza constructor com novas dependências 
  - Adiciona contexto para realizar ação em transaction do MongoDB
  - Adiciona uso do `pedidoQueueManager.enqueueMessage` para enviar mensagem à fila

### Testes realizados
- Testar a atualização de um pagamento
  - Verificar se houve a publicação da mensagem
- Testar a atualização de um pagamento simulando falha
  - Troquei o link da fila, forçando um erro
  - Validar se o contexto de trasaction está funcionando 

> [!WARNING]
> **Ponto de atenção!**
> MongoDB só permite transactions em instancias replicaSet
> Para os testes locais tive que trocar para um instancia do MongoDB Atlas e deixar explicito na string de conexão qual era o replicaSet
> - ex: `mongodb+srv://<user>:<password>@cluster0.dn0ahsv.mongodb.net/?replicaSet=atlas-bwo1ni-shard-0`
> - O trecho `/?replicaSet=atlas-bwo1ni-shard-0` tem que estar presente na string de conexão