### PR TITLE
chore: corrige alertas apontados no OWASP ZAP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4172,9 +4172,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "axios": "^1.5.0",
         "express": "^4.18.2",
         "express-async-errors": "^3.1.1",
+        "helmet": "^7.1.0",
         "mongoose": "^7.2.3",
+        "nocache": "^4.0.0",
         "swagger-ui-express": "^4.6.3"
       },
       "devDependencies": {
@@ -4052,6 +4054,14 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.1.0.tgz",
+      "integrity": "sha512-g+HZqgfbpXdCkme/Cd/mZkV0aV3BZZZSugecH03kl38m/Kmdx8jKjBikpDj2cr+Iynv4KpYEviojNdTJActJAg==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -5372,6 +5382,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nocache": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nocache/-/nocache-4.0.0.tgz",
+      "integrity": "sha512-AntnTbmKZvNYIsTVPPwv7dfZdAfo/6H/2ZlZACK66NAOQtIApxkB/6pf/c+s+ACW8vemGJzUCyVTssrzNUK6yQ==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "axios": "^1.5.0",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
+    "helmet": "^7.1.0",
     "mongoose": "^7.2.3",
+    "nocache": "^4.0.0",
     "swagger-ui-express": "^4.6.3"
   },
   "devDependencies": {

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -1,10 +1,13 @@
 import express from "express";
+import helmet from "helmet";
+import nocache from "nocache";
 import { serve, setup } from "swagger-ui-express";
 import { createMongoConnection } from "external/mongo";
 import { errorHandler } from "./middlewares";
 import { makeServerRouter } from "./routes";
 import { requestLogger } from "../utils/requestLogger";
 import { SwaggerConfig } from "./docs";
+import { serverConfig } from "config";
 
 require("dotenv").config();
 
@@ -12,6 +15,17 @@ function buildServer() {
     createMongoConnection();
 
     const server = express();
+
+    server.disable("x-powered-by");
+    server.use(helmet());
+    server.use(nocache());
+
+    if (serverConfig.isProduction) {
+        server.use(helmet.hsts({
+            maxAge: 31536000,
+            includeSubDomains: true
+        }));
+    }
 
     server.use(requestLogger);
 


### PR DESCRIPTION
- Desabilita "x-powered-by"
- Adiciona lib Helmet que tem os middlewares que o OWASP apontou 
   - sobre o helmet, teoricamente precisa configurar o helmet.hsts porém o GPT respondeu isso:
       _Lembre-se de que o uso do HSTS é recomendado apenas se você estiver servindo seu site exclusivamente via HTTPS. Se você 
       ainda suporta HTTP, não ative essa configuração, pois isso pode impedir que os usuários acessem seu site._ (coloquei na config apenas para quando está em produção que vai ser HTTPS)
       
- Adiciona lib nocache para configurar o header Cache-Control
- Corrige dependências apontadas como vulnerabildades no npm

links uteis: 
https://expressjs.com/en/advanced/best-practice-security.html
https://blog.logrocket.com/using-helmet-node-js-secure-application/
https://retz.dev/blog/setting-security-headers-for-web-app:-nginx-express-and-react.
https://cheatsheetseries.owasp.org/cheatsheets/Nodejs_Security_Cheat_Sheet.html